### PR TITLE
Add Apache setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ Open `http://localhost:8000/` in your browser and submit a news article URL.
 ## Deployment
 
 For instructions on deploying the stack to a VPS using Docker Compose, see [docs/VPS_SETUP.md](docs/VPS_SETUP.md).
+For Apache proxy instructions, see [docs/APACHE_SETUP.md](docs/APACHE_SETUP.md).

--- a/docs/APACHE_SETUP.md
+++ b/docs/APACHE_SETUP.md
@@ -1,0 +1,42 @@
+# Apache Reverse Proxy Setup
+
+This guide explains how to forward traffic from Apache to the FastAPI backend running on port 8000. The instructions target Debian 12 servers and assume the project lives under a directory typically created by ISPConfig such as `/var/www/clients/client0/web1/`.
+
+## Prerequisites
+
+- Debian 12 with Apache 2 installed
+- Docker Engine and Docker Compose
+
+Install Docker if it is not already present:
+```bash
+sudo apt update
+sudo apt install -y docker.io docker-compose
+```
+
+Enable the required Apache modules:
+```bash
+sudo a2enmod proxy proxy_http
+```
+
+## Example VirtualHost
+
+Create a site configuration, e.g. `/etc/apache2/sites-available/ainews.conf`:
+```apache
+<VirtualHost *:80>
+    ServerName example.com
+    DocumentRoot /var/www/clients/client0/web1/web
+
+    ProxyPreserveHost On
+    ProxyPass / http://localhost:8000/
+    ProxyPassReverse / http://localhost:8000/
+</VirtualHost>
+```
+This assumes the project files and `docker-compose.yml` are located in `/var/www/clients/client0/web1/`.
+
+## Enable the Site
+
+```bash
+sudo a2ensite ainews.conf
+sudo systemctl reload apache2
+```
+After reloading Apache, requests to `example.com` will be forwarded to the FastAPI service.

--- a/docs/VPS_SETUP.md
+++ b/docs/VPS_SETUP.md
@@ -66,6 +66,7 @@ Access the application in your browser at `http://<VPS_IP>:8000/`.
 ## 5. Set Up Reverse Proxy (Optional)
 
 To expose the service on your domain name and handle TLS, you can use a reverse proxy like Nginx or Traefik. A minimal Nginx configuration might look like:
+For Apache reverse proxy instructions, see [APACHE_SETUP.md](APACHE_SETUP.md).
 
 ```nginx
 server {


### PR DESCRIPTION
## Summary
- add instructions for configuring Apache as a reverse proxy
- link the new guide from `README.md` and `docs/VPS_SETUP.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68423cd02670832d89bf64827e0b7c11