### PR TITLE
Add Apache ISPConfig deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ Open `http://localhost:8000/` in your browser and submit a news article URL.
 ## Deployment
 
 For instructions on deploying the stack to a VPS using Docker Compose, see [docs/VPS_SETUP.md](docs/VPS_SETUP.md).
+
+If your server is managed by ISPConfig with Apache, you can clone the repository directly inside your web root, for example `/var/www/clients/client0/web1/`, and run Docker from there. See [docs/APACHE_SETUP.md](docs/APACHE_SETUP.md) for details.

--- a/docs/APACHE_SETUP.md
+++ b/docs/APACHE_SETUP.md
@@ -1,0 +1,35 @@
+# Running with Apache and ISPConfig
+
+This guide explains how to start the AI News Pipeline when your server is managed by ISPConfig and Apache serves the site from `/var/www/clients/client0/web1/` (adjust the path if your ISPConfig setup uses a different client or web number).
+
+## 1. Clone the Repository
+
+```
+cd /var/www/clients/client0/web1/
+git clone https://github.com/your-org/ai-news-pipeline.git
+cd ai-news-pipeline
+```
+
+The project files now reside within the web root managed by ISPConfig.
+
+## 2. Build and Start the Containers
+
+Run the stack from the project directory:
+
+```
+docker compose up --build -d
+```
+
+The command downloads images (if necessary) and starts the services in detached mode.
+
+## 3. Permissions
+
+Depending on your ISPConfig configuration, the files in `/var/www/clients/client0/web1/ai-news-pipeline` should typically be owned by `web1:client0`.
+If you encounter permission errors, adjust ownership and allow the web user to run Docker:
+
+```
+sudo chown -R web1:client0 /var/www/clients/client0/web1/ai-news-pipeline
+sudo usermod -aG docker web1   # log out and back in for this to take effect
+```
+
+Alternatively, run `sudo docker compose` as `root`.


### PR DESCRIPTION
## Summary
- document how to deploy under ISPConfig/Apache
- mention the path `/var/www/clients/client0/web1/` for cloning
- reference the new doc from the README

## Testing
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68423cd1c33c832db960b5b8e0b47184